### PR TITLE
Add unit tests for mapper and controller

### DIFF
--- a/src/test/java/com/blockchain/blockpulseservice/controller/AnalysisControllerTest.java
+++ b/src/test/java/com/blockchain/blockpulseservice/controller/AnalysisControllerTest.java
@@ -1,0 +1,60 @@
+package com.blockchain.blockpulseservice.controller;
+
+import com.blockchain.blockpulseservice.model.FeeClassification;
+import com.blockchain.blockpulseservice.model.PatternType;
+import com.blockchain.blockpulseservice.model.TransactionWindowSnapshotDTO;
+import com.blockchain.blockpulseservice.model.dto.AnalyzedTransactionDTO;
+import com.blockchain.blockpulseservice.service.AnalysisStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.codec.ServerSentEvent;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AnalysisControllerTest {
+
+    private AnalysisStream analysisStream;
+    private AnalysisController controller;
+
+    @BeforeEach
+    void setUp() {
+        analysisStream = Mockito.mock(AnalysisStream.class);
+        controller = new AnalysisController(analysisStream);
+    }
+
+    @Test
+    void streamShouldReturnServerSentEventsFromStream() {
+        AnalyzedTransactionDTO dto = new AnalyzedTransactionDTO(
+                "id1",
+                1,
+                Instant.now(),
+                BigDecimal.ONE,
+                BigDecimal.TEN,
+                123,
+                Instant.now(),
+                Set.of(PatternType.SURGE),
+                FeeClassification.NORMAL,
+                false,
+                new TransactionWindowSnapshotDTO(0, BigDecimal.ZERO, BigDecimal.ZERO, 0)
+        );
+        when(analysisStream.flux()).thenReturn(Flux.just(dto));
+
+        Flux<ServerSentEvent<AnalyzedTransactionDTO>> result = controller.stream();
+
+        StepVerifier.create(result)
+                .assertNext(event -> assertThat(event.data()).isEqualTo(dto))
+                .verifyComplete();
+
+        verify(analysisStream).flux();
+    }
+}
+

--- a/src/test/java/com/blockchain/blockpulseservice/mapper/TransactionMapperTest.java
+++ b/src/test/java/com/blockchain/blockpulseservice/mapper/TransactionMapperTest.java
@@ -1,0 +1,52 @@
+package com.blockchain.blockpulseservice.mapper;
+
+import com.blockchain.blockpulseservice.model.Transaction;
+import com.blockchain.blockpulseservice.model.dto.MempoolTransactionsDTOWrapper;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransactionMapperTest {
+
+    private final TransactionMapper mapper = new TransactionMapper();
+
+    @Test
+    void mapToTransaction_shouldMapAllFields() {
+        Instant now = Instant.now();
+        List<MempoolTransactionsDTOWrapper.TransactionDTO> dtos = List.of(
+                new MempoolTransactionsDTOWrapper.TransactionDTO("hash1", 123, BigDecimal.TEN, BigDecimal.ONE, now),
+                new MempoolTransactionsDTOWrapper.TransactionDTO("hash2", 456, BigDecimal.ONE, new BigDecimal("0.5"), now.plusSeconds(1))
+        );
+
+        List<Transaction> result = mapper.mapToTransaction(dtos);
+
+        assertThat(result).hasSize(2);
+        Transaction first = result.get(0);
+        assertThat(first.hash()).isEqualTo("hash1");
+        assertThat(first.vSize()).isEqualTo(123);
+        assertThat(first.totalFee()).isEqualTo(BigDecimal.TEN);
+        assertThat(first.feePerVSize()).isEqualTo(BigDecimal.ONE);
+        assertThat(first.time()).isEqualTo(now);
+
+        Transaction second = result.get(1);
+        assertThat(second.hash()).isEqualTo("hash2");
+        assertThat(second.vSize()).isEqualTo(456);
+        assertThat(second.totalFee()).isEqualTo(BigDecimal.ONE);
+        assertThat(second.feePerVSize()).isEqualTo(new BigDecimal("0.5"));
+        assertThat(second.time()).isEqualTo(now.plusSeconds(1));
+    }
+
+    @Test
+    void mapToTransaction_withEmptyListReturnsEmpty() {
+        List<MempoolTransactionsDTOWrapper.TransactionDTO> dtos = List.of();
+
+        List<Transaction> result = mapper.mapToTransaction(dtos);
+
+        assertThat(result).isEmpty();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests verifying TransactionMapper correctly converts DTOs to domain
- add tests ensuring AnalysisController exposes stream from AnalysisStream

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7a5c7f7c832db82154436784b02b